### PR TITLE
エラー時にもログイン可能にする設定

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -147,7 +147,7 @@ Devise.setup do |config|
   # without confirming their account.
   # Default is 0.days, meaning the user cannot access the website without
   # confirming their account.
-  # config.allow_unconfirmed_access_for = 2.days
+  config.allow_unconfirmed_access_for = 300.days
 
   # A period that the user is allowed to confirm their account before their
   # token becomes invalid. For example, if set to 3.days, the user can confirm


### PR DESCRIPTION
# What
- エラー時にもログイン可能にする設定

# Why
- メール認証機能の実装のため